### PR TITLE
Fix timer continuing after test submission

### DIFF
--- a/src/app/practice-tests/page.tsx
+++ b/src/app/practice-tests/page.tsx
@@ -69,7 +69,13 @@ export default function PracticeTestPage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <h1 className="text-2xl font-bold text-gray-900">Practice Test</h1>
-        <Timer timeLeft={timeLeft} setTimeLeft={setTimeLeft} onTimeUp={handleSubmit} />
+        {!isSubmitted && (
+          <Timer
+            timeLeft={timeLeft}
+            setTimeLeft={setTimeLeft}
+            onTimeUp={handleSubmit}
+          />
+        )}
       </div>
 
       {/* Question Card */}


### PR DESCRIPTION
## Summary
- stop the practice test timer once the test is submitted

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb90677548324b0a692bcdfd992bb