### PR TITLE
Add Prisma setup with MongoDB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="mongodb+srv://centillionc0919:<db_password>@cluster1.0qlkbj7.mongodb.net/?retryWrites=true&w=majority&appName=Cluster1"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ Backend: Next.js
 
 Database: MongoDB
 
+## Prisma setup
+
+This project uses [Prisma](https://www.prisma.io/) as an ORM for MongoDB.
+
+1. Copy `.env.example` to `.env` and provide your MongoDB password:
+
+```bash
+cp .env.example .env
+# edit .env and replace <db_password>
+```
+
+2. Generate the Prisma client:
+
+```bash
+npm run generate
+```
+
+3. Start the development server:
+
+```bash
+npm run dev
+```
+
 Mobile: React Native
 
 Authentication: Next Auth

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,12 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@prisma/client": "^6.9.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "postcss": "^8",
+        "prisma": "^6.9.0",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
@@ -751,6 +753,99 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.9.0.tgz",
+      "integrity": "sha512-Gg7j1hwy3SgF1KHrh0PZsYvAaykeR0PaxusnLXydehS96voYCGt1U5zVR31NIouYc63hWzidcrir1a7AIyCsNQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
+      "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/config/node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
+      "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
+      "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/fetch-engine": "6.9.0",
+        "@prisma/get-platform": "6.9.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
+      "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
+      "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/get-platform": "6.9.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
+      "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -2436,6 +2531,32 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/prisma": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
+      "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.9.0",
+        "@prisma/engines": "6.9.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "prisma": "prisma",
+    "generate": "prisma generate",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@fontsource/inter": "^5.1.0",
@@ -30,10 +33,12 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@prisma/client": "^6.9.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "postcss": "^8",
+    "prisma": "^6.9.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,28 @@
+ datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+ }
+
+ generator client {
+  provider = "prisma-client-js"
+ }
+
+ model Question {
+  id            String   @id @default(auto()) @map("_id") @db.ObjectId
+  question      String
+  options       String[]
+  correctAnswer String
+  explanation   String?
+  subject       String
+ }
+
+ model StudyMaterial {
+  id          String @id @default(auto()) @map("_id") @db.ObjectId
+  title       String
+  subject     String
+  level       String
+  description String
+  duration    String
+  lessons     Int
+  image       String
+ }


### PR DESCRIPTION
## Summary
- set up Prisma schema and MongoDB datasource
- document Prisma usage in README
- add example environment file
- add Prisma scripts in package.json

## Testing
- `npm run generate` *(fails: Failed to fetch prisma engine binaries)*
- `npm run lint` *(fails: Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_683fd2d905708324a650c6d372f8a25b